### PR TITLE
Switch "1250+ ACT" requirement to "1250+ SAT"

### DIFF
--- a/_posts/2020-03-02-applications-open.md
+++ b/_posts/2020-03-02-applications-open.md
@@ -3,7 +3,7 @@ layout: default
 title: "Applications Open!"
 ---
 
-Need financial aid? Have a 3.0+ GPA or 1250+ ACT or 28+ ACT? How does receiving up to **$32,500 over 4 years** sound?
+Need financial aid? Have a 3.0+ GPA or 1250+ SAT or 28+ ACT? How does receiving up to **$32,500 over 4 years** sound?
 
 We are now accepting applications for the Fall 2020 <strong><span class="has-text-primary">Community Engaged Scholars</span> <span class="has-text-usf-gold">in</span> <span class="has-text-primary">Computer Science</span></strong> scholarship program at the University of San Francisco. For full consideration, applications are due on **Friday April 10, 2020**.
 


### PR DESCRIPTION
Program requirements listed as a "3.0+ GPA, 1250+ ACT or 28+ ACT"
It is safe to assume that the 1250+ score requirement is intended to be SAT
Replace "1250+ ACT" with "1250+ SAT"